### PR TITLE
[brew] Add option to uninstall casks with `--zap`

### DIFF
--- a/extensions/brew/package.json
+++ b/extensions/brew/package.json
@@ -56,6 +56,14 @@
       "required": false,
       "title": "Custom Brew Executable Path",
       "description": "Set this if your brew executable is in a non-standard location"
+    },
+    {
+      "name": "zapCask",
+      "type": "checkbox",
+      "required": false,
+      "title": "Zap Casks",
+      "label": "Add --zap to brew uninstall --cask",
+      "description": "Run cask uninstall with the --zap option for a more complete uninstallation of files associated with cask."
     }
   ],
   "dependencies": {

--- a/extensions/brew/src/brew.ts
+++ b/extensions/brew/src/brew.ts
@@ -284,7 +284,7 @@ export async function brewInstall(installable: Cask | Formula, cancel?: AbortCon
 
 export async function brewUninstall(installable: Cask | Nameable, cancel?: AbortController): Promise<void> {
   const identifier = brewIdentifier(installable);
-  await execBrew(`rm ${brewCaskOption(installable)} ${identifier}`, cancel);
+  await execBrew(`rm ${brewCaskOption(installable, true)} ${identifier}`, cancel);
 }
 
 export async function brewUpgrade(upgradable: Cask | Nameable, cancel?: AbortController): Promise<void> {
@@ -337,7 +337,7 @@ export function brewInstallCommand(installable: Cask | Formula | Nameable): stri
 
 export function brewUninstallCommand(installable: Cask | Formula | Nameable): string {
   const identifier = brewIdentifier(installable);
-  return `${brewExecutable()} uninstall ${brewCaskOption(installable)} ${identifier}`.replace(/ +/g, " ");
+  return `${brewExecutable()} uninstall ${brewCaskOption(installable, true)} ${identifier}`.replace(/ +/g, " ");
 }
 
 export function brewUpgradeCommand(upgradable: Cask | Formula | Nameable): string {
@@ -450,8 +450,8 @@ function brewIdentifier(item: Cask | Nameable): string {
   return isCask(item) ? item.token : item.name;
 }
 
-function brewCaskOption(maybeCask: Cask | Nameable): string {
-  return isCask(maybeCask) ? "--cask" : "";
+function brewCaskOption(maybeCask: Cask | Nameable, zappable = false): string {
+  return isCask(maybeCask) ? "--cask" + (zappable && preferences.zapCask ? " --zap" : "") : "";
 }
 
 function isCask(maybeCask: Cask | Nameable): maybeCask is Cask {

--- a/extensions/brew/src/preferences.ts
+++ b/extensions/brew/src/preferences.ts
@@ -3,4 +3,5 @@ import { getPreferenceValues } from "@raycast/api";
 export const preferences: {
   greedyUpgrades: boolean;
   customBrewPath?: string;
+  zapCask: boolean;
 } = getPreferenceValues();


### PR DESCRIPTION
## Description

<!-- A summary of your change. If you add a new extension or command, explain what it does. -->
Just adds a simple option which only when checked runs cask uninstall commands with `--zap`. Which can be quite useful when you want to get rid of *all* of the program. (https://docs.brew.sh/Cask-Cookbook#zap-purpose)

## Screencast

<!-- If you add a new extension or command, include a screencast (or screenshot for straightforward changes). A good screencast will make the review much faster - especially if your extension requires registration in other services.  -->

## Checklist

- [x] I read the [extension guidelines](https://developers.raycast.com/basics/prepare-an-extension-for-store)
- [x] I read the [documentation about publishing](https://developers.raycast.com/basics/publish-an-extension)
- [x] I ran `npm run build` and [tested this distribution build in Raycast](https://developers.raycast.com/basics/prepare-an-extension-for-store#metadata-and-configuration)
- [x] I checked that files in the `assets` folder are used by the extension itself
- [x] I checked that assets used by the `README` are placed outside of the `metadata` folder
